### PR TITLE
Fix draw_line printf argument

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -102,9 +102,9 @@ log_error() {
 draw_line() {
     local char="${1:-─}"
     local width="${2:-75}"
-    printf "${C_DIM}"
-    printf "%*s\n" "$width" | tr ' ' "$char"
-    printf "${C_RESET}"
+    printf "%s" "${C_DIM}"
+    printf "%*s\n" "$width" "" | tr ' ' "$char"
+    printf "%s" "${C_RESET}"
 }
 
 show_header() {


### PR DESCRIPTION
## Summary
- ensure `draw_line` prints expected separators by passing missing printf argument
- guard color escape sequences with format specifiers for safer output

## Testing
- `shellcheck install.sh`
- `bash -n install.sh`


------
https://chatgpt.com/codex/tasks/task_e_6899b70e0778832fa7c474d53e6ce3f2