### PR TITLE
Fix draw_line color escape rendering

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -102,9 +102,9 @@ log_error() {
 draw_line() {
     local char="${1:-─}"
     local width="${2:-75}"
-    printf "${C_DIM}"
-    printf "%*s\n" "$width" | tr ' ' "$char"
-    printf "${C_RESET}"
+    printf "%b" "${C_DIM}"
+    printf "%*s\n" "$width" "" | tr ' ' "$char"
+    printf "%b" "${C_RESET}"
 }
 
 show_header() {


### PR DESCRIPTION
## Summary
- interpret ANSI color codes in draw_line so escape sequences aren't printed

## Testing
- `shellcheck install.sh`
- `bash -n install.sh`


------
https://chatgpt.com/codex/tasks/task_e_6899b70e0778832fa7c474d53e6ce3f2